### PR TITLE
Add a sniff for missing return types on closures (DEV-2878)

### DIFF
--- a/PinnacleCodingStandard/Sniffs/Closures/MissingReturnTypeForClosureSniff.php
+++ b/PinnacleCodingStandard/Sniffs/Closures/MissingReturnTypeForClosureSniff.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PinnacleCodingStandard\Sniffs\Closures;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class MissingReturnTypeForClosureSniff implements Sniff
+{
+    /**
+     * The name of the sniff.
+     */
+    private const NAME = 'MissingReturnTypeForClosure';
+
+    public function register()
+    {
+        return [
+            T_CLOSURE,
+        ];
+    }
+
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $endOfStatementPointer   = $phpcsFile->findEndOfStatement($stackPtr);
+        $endOfDeclarationPointer = $phpcsFile->findNext(T_OPEN_CURLY_BRACKET, $stackPtr, $endOfStatementPointer);
+        $returnTypeColonPointer  = $phpcsFile->findNext(T_COLON, $stackPtr, $endOfDeclarationPointer);
+        if ($returnTypeColonPointer === false) {
+            $phpcsFile->addError('Closure missing return type.', $stackPtr, self::NAME);
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "phpcodesniffer-standard",
     "prefer-stable": true,
     "require": {
-        "php": "^7.4",
+        "php": "^7.4 || ^8.0",
         "slevomat/coding-standard": "^6.3",
         "squizlabs/php_codesniffer": "^3.5"
     },


### PR DESCRIPTION
Adds a sniff to detect missing return types on closures.

I also took this opportunity to change the PHP requirement from `^7.4` to `^7.4 || ^8.0`, since all of the dependent packages at the current version are compatible with both.

For testing, I manually added the new sniff to my Retain project, and ran through the following scenarios to make sure it was working:

- Write a standard closure without a return type, and verify the sniff shows a warning.
- Add a return type to the closure, and verify the warning disappears.
- Write a closure using `fn` closure syntax. Verify the sniff doesn't show a warning for this type of closure.