### PR TITLE
Fix - Update looksLikeTestFunction to support null namespace values

### DIFF
--- a/PinnacleCodingStandard/Sniffs/Commenting/MissingTestAnnotationOnTestFunctionSniff.php
+++ b/PinnacleCodingStandard/Sniffs/Commenting/MissingTestAnnotationOnTestFunctionSniff.php
@@ -57,9 +57,9 @@ class MissingTestAnnotationOnTestFunctionSniff implements Sniff
     /**
      * Whether the specified function name looks like a test function according to our format.
      */
-    private function looksLikeTestFunction(string $namespace, string $functionName): bool
+    private function looksLikeTestFunction(?string $namespace, string $functionName): bool
     {
-        if (substr($namespace, 0, 6) !== 'Tests\\') {
+        if ($namespace === null || substr($namespace, 0, 6) !== 'Tests\\') {
             // Function doesn't belong to a class in the Tests\ namespace.
             return false;
         }


### PR DESCRIPTION
An error was being thrown in the survey-api project when running code sniffer I narrowed it down to the namespace value being null when being passed into the `looksLikeTestFunction` function.