### PR TITLE
Make version requirements less restrictive. (DEV-2663)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "phpcodesniffer-standard",
     "prefer-stable": true,
     "require": {
-        "php": ">=7.4",
+        "php": "^7.4 || 8.0.* || 8.1.*",
         "slevomat/coding-standard": ">=6.3",
         "squizlabs/php_codesniffer": ">=3.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
     "type": "phpcodesniffer-standard",
     "prefer-stable": true,
     "require": {
-        "php": "^7.4 || ^8.0",
-        "slevomat/coding-standard": "^6.3",
-        "squizlabs/php_codesniffer": "^3.5"
+        "php": ">=7.4",
+        "slevomat/coding-standard": ">=6.3",
+        "squizlabs/php_codesniffer": ">=3.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The version requirements were too strict for us to get the correct versions of slevomat/code sniffer. For forward-compatibility reasons, I think it makes sense to be less restrictive on our version constraints, and let the version constraints of those libraries determine compatibility.