### PR TITLE
Fix bug where constructor pointers don't update for new files

### DIFF
--- a/PinnacleCodingStandard/Sniffs/Variables/UninitializedNullableClassPropertySniff.php
+++ b/PinnacleCodingStandard/Sniffs/Variables/UninitializedNullableClassPropertySniff.php
@@ -17,17 +17,20 @@ class UninitializedNullableClassPropertySniff implements Sniff
      */
     private const NAME = 'UninitializedNullableClassProperty';
 
-    private bool $checkedForConstructor;
+    private bool    $checkedForConstructor;
 
-    private ?int $constructorPointer;
+    private ?int    $constructorPointer;
 
-    private ?int $endOfConstructorParametersPointer;
+    private ?int    $endOfConstructorParametersPointer;
+
+    private ?string $fileName;
 
     public function __construct()
     {
         $this->constructorPointer                = null;
         $this->endOfConstructorParametersPointer = null;
         $this->checkedForConstructor             = false;
+        $this->fileName                          = null;
     }
 
     public function register(): array
@@ -39,6 +42,17 @@ class UninitializedNullableClassPropertySniff implements Sniff
 
     public function process(File $phpcsFile, $stackPtr)
     {
+        $fileName = $phpcsFile->getFilename();
+        if ($this->fileName === null) {
+            $this->fileName = $fileName;
+        }
+
+        // Re-check the constructor position when we move on to a different file.
+        if ($this->fileName !== $fileName) {
+            $this->checkedForConstructor = false;
+            $this->fileName              = $fileName;
+        }
+
         // Find the pointer to the constructor if we haven't done so already.
         if (!$this->checkedForConstructor) {
             $this->constructorPointer                = $this->findConstructorPointer($phpcsFile);


### PR DESCRIPTION
This fixes an issue where the constructor pointers weren't being updated when the sniff moved onto a new file. We believe something changed with a recent version of code sniffer where the sniffs are no longer being re-instantiated for each file.

This was tested on Survey API by copying this sniff into the project, and adding some debug logging. We have confirmed the Github action passes with these changes.