### PR TITLE
CU-868ay3v6d - Update pinnacleqi/coding-standard to use PHP 8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,18 +4,13 @@
     "type": "phpcodesniffer-standard",
     "prefer-stable": true,
     "require": {
-        "php": "^7.4 || 8.0.* || 8.1.* || 8.2.* || 8.3.*",
+        "php": "^7.4 || ^8.0",
         "slevomat/coding-standard": ">=6.3",
         "squizlabs/php_codesniffer": ">=3.5"
     },
     "autoload": {
         "psr-4": {
             "PinnacleCodingStandard\\": "PinnacleCodingStandard"
-        }
-    },
-    "config": {
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,13 +4,18 @@
     "type": "phpcodesniffer-standard",
     "prefer-stable": true,
     "require": {
-        "php": "^7.4 || 8.0.* || 8.1.*",
+        "php": "^7.4 || 8.0.* || 8.1.* || 8.2.* || 8.3.*",
         "slevomat/coding-standard": ">=6.3",
         "squizlabs/php_codesniffer": ">=3.5"
     },
     "autoload": {
         "psr-4": {
             "PinnacleCodingStandard\\": "PinnacleCodingStandard"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     }
 }


### PR DESCRIPTION
Updated PHP version in composer
![image](https://github.com/user-attachments/assets/74494abd-f107-457d-a5df-59c770983bde)
